### PR TITLE
fix: fix broken links in post

### DIFF
--- a/source/_posts/zsh-antidote-config.md
+++ b/source/_posts/zsh-antidote-config.md
@@ -8,7 +8,7 @@ categories: Notes
 date: 2023-02-18 17:44:47
 ---
 
-之前介绍了使用[antigen](zsh-config) 和 [sheldon](zsh-sheldon-config) 管理 Zsh 配置，由于 antigen 已经停止维护了，后面就有了[antibody](https://getantibody/antibody)，但是这个也停止维护了，最终就有了继任者 [antidote](https://github.com/mattmc3/antidote)，这几个使用上都大同小异。
+之前介绍了使用 {% post_link zsh-config antigen %} 和 {% post_link zsh-sheldon-config sheldon %} 管理 Zsh 配置，由于 antigen 已经停止维护了，后面就有了 [antibody](https://getantibody/antibody)，但是这个也停止维护了，最终就有了继任者 [antidote](https://github.com/mattmc3/antidote)，这几个使用上都大同小异。
 
 - 安装
 


### PR DESCRIPTION
您好，感谢您分享多种 Zsh 配置的管理方式，我收益良多。

我发现[使用 Antidote 管理 Zsh 配置](https://gythialy.github.io/zsh-antidote-config/)中 antigen 和 sheldon 的链接有问题，导致 404 Not Found。

<img width="1452" alt="image" src="https://github.com/user-attachments/assets/372b9b59-7a9a-4513-bff2-2b10efaae665" />

我参考了 [oh-my-zsh-with-custom-plugins.md](https://github.com/gythialy/gythialy.github.io/blob/main/source/_posts/oh-my-zsh-with-custom-plugins.md?plain=1#L10) 中的 `{% post_link zsh-config antigen %}` 写法来修复了这两个链接，并在本地运行了 hexo 确认过链接已经没问题了。

我还发现您会在 alphanumeric 文字和 CJK 文字中留下空格，所以顺便在 antibody 前添加了一个空格。

烦请确认。